### PR TITLE
Refactor animation in contacto section to home page

### DIFF
--- a/app/routes/_index/components/Contacto.tsx
+++ b/app/routes/_index/components/Contacto.tsx
@@ -30,7 +30,7 @@ export default function Contacto() {
   const [animation, setAnimation] = useState("");
   const section = useRef(null);
 
-  const options = { root: null, rootMargin: "0px", threshold: 1 };
+  const options = { root: null, rootMargin: "0px", threshold: 0.1 };
 
   useEffect(() => {
     const observer = new IntersectionObserver(showContacs, options);
@@ -70,7 +70,7 @@ export default function Contacto() {
             }}
           >
             <span>¿Alguna duda o </span>
-            <span className="font-serif italic">necesitas ayuda </span>
+            <span className="font-serif italic">necesitas ayuda</span>
             <span>?</span>
           </h2>
           <p className="text-xl text-gray-600 font-semibold">


### PR DESCRIPTION
Se cambia la opción del threshold ya que en pantallas grandes la animación comenzaba cuando toda la sección se mostrara por completo, causando algo de incertidumbre al hacer scroll.

![image](https://github.com/pensemosweb/website/assets/120123220/dbb8770a-e2c5-4646-aa3b-27e2328c6c26)
